### PR TITLE
Fixed bug by which WaitAll() can return too early.

### DIFF
--- a/ThreadPool.h
+++ b/ThreadPool.h
@@ -50,12 +50,13 @@ public:
         {
             std::lock_guard<std::mutex> lock(_queueMutex);
             _queue.emplace(job);
+            // scoped lock        
+            {            
+                std::lock_guard<std::mutex> lock(_jobsLeftMutex);            
+                ++_jobsLeft;        
+            }            
         }
-        // scoped lock
-        {
-            std::lock_guard<std::mutex> lock(_jobsLeftMutex);
-            ++_jobsLeft;
-        }
+
         _jobAvailableVar.notify_one();
     }
 


### PR DESCRIPTION
AddJob() was releasing the _queueMutex before acquiring the _jobsLeftMutex an increasing _jobsLeft. 
That risks a thread(s) starting a job but a synchronous call to WaitAll() could see 0 jobs left and exit.
The fix is to retain the _queueMutex (there by blocking the worker threads) until _jobsLeft is incremented.

NB: _jobsLeft is a good candidate for a spin-lock as the critical sections it governs are tiny (almost minimal).